### PR TITLE
Enable github pages and CNAME for harveyneeds.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+harveyneeds.org


### PR DESCRIPTION
should enable github pages with the gh-pages branch and the CNAME

Note: we'll need to automate this publishing, but didn't want to force that decision right meow.